### PR TITLE
remove getEupsProductName method from CameraMapper subclasses

### DIFF
--- a/python/lsst/obs/sdss/sdssMapper.py
+++ b/python/lsst/obs/sdss/sdssMapper.py
@@ -33,8 +33,10 @@ import lsst.afw.image.utils as afwImageUtils
 import lsst.meas.algorithms as measAlgo
 
 class SdssMapper(CameraMapper):
+    packageName = 'obs_sdss'
+
     def __init__(self, inputPolicy=None, **kwargs):
-        policyFile = pexPolicy.DefaultPolicyFile("obs_sdss", "SdssMapper.paf", "policy")
+        policyFile = pexPolicy.DefaultPolicyFile(self.packageName, "SdssMapper.paf", "policy")
         policy = pexPolicy.Policy(policyFile)
 
         self.doFootprints = False


### PR DESCRIPTION
Replaced by the packageName class variable and getPackageName() method.