### PR TITLE
Fix incorrect python type for processCcd_config

### DIFF
--- a/policy/SdssMapper.paf
+++ b/policy/SdssMapper.paf
@@ -389,7 +389,7 @@ datasets: {
     }
     processCcd_config: {
         template:      "config/processCcd.py"
-        python:        "lsst.obs.sdss.processCcdSdss.ProcessCcdSdssConfig"
+        python:        "lsst.pipe.tasks.processCcd.ProcessCcdConfig"
         persistable:      "Config"
         storage:    "ConfigStorage"
         tables:        raw


### PR DESCRIPTION
Fix the Python type for SdssMapper.paf dataset type
"processCcd_config`. It was
lsst.obs.sdss.processCcdSdss.ProcessCcdSdssConfig
instead of lsst.pipe.tasks.processCcd.ProcessCcdConfig