### PR TITLE
Update config overrides for star selector registry

### DIFF
--- a/config/processCcd.py
+++ b/config/processCcd.py
@@ -18,9 +18,9 @@ config.charImage.detectAndMeasure.measurement.algorithms["base_CircularApertureF
 config.charImage.detectAndMeasure.measurement.slots.apFlux = "base_CircularApertureFlux_7_0"
 config.charImage.detectAndMeasure.measurement.slots.calibFlux = "base_CircularApertureFlux_7_0"
 
-# we rarely run PSF determination on SDSS data, so we have to run our own star selector instead
-from lsst.meas.algorithms import ObjectSizeStarSelectorTask
-config.charImage.detectAndMeasure.measureApCorr.starSelector.retarget(ObjectSizeStarSelectorTask)
+# we rarely run PSF determination on SDSS data, so the flag needed by the default star selector
+# for measuring aperture correction is not available; run our own star selector instead
+config.charImage.detectAndMeasure.measureApCorr.starSelector.name = "objectSize"
 
 config.calibrate.detectAndMeasure.detection.background.binSize = 512
 config.calibrate.detectAndMeasure.detection.background.binSize = 512


### PR DESCRIPTION
MeasureApCorrTask now has its star selector in a RegistryField
instead of a ConfigurableField; update a config override accordingly.