### PR TITLE
Fix error calling MaskedImageF copy constructor

### DIFF
--- a/python/lsst/obs/sdss/sdssNullIsr.py
+++ b/python/lsst/obs/sdss/sdssNullIsr.py
@@ -127,12 +127,12 @@ class SdssNullIsrTask(pipeBase.Task):
         mi = afwImage.MaskedImageF(image, mask, var)
 
         if self.config.removeOverlap:
-            bbox = mi.getBBox(afwImage.LOCAL)
+            bbox = mi.getBBox()
             begin = bbox.getBegin()
             extent = bbox.getDimensions()
             extent -= afwGeom.Extent2I(0, self.config.overlapSize)
             tbbox = afwGeom.BoxI(begin, extent)
-            mi = afwImage.MaskedImageF(mi, tbbox, True)
+            mi = afwImage.MaskedImageF(mi, tbbox)
 
         exposure = afwImage.ExposureF(mi, wcs)
         expInfo = exposure.getInfo()


### PR DESCRIPTION
The original code may have wanted a deep copy (based on the
third argument being true) but was actually specifying origin=LOCAL.
Fortunately the code actually wanted origin=LOCAL and had
no obvious need for a deep copy (so the True might possibly have been
an unfortunate way of spelling "LOCAL").

I tweaked the code so that the default PARENT origin could be
used instead and continued not to make a deep copy.