### PR TITLE
DM-9953: config: strip out background matching

### DIFF
--- a/config/assembleCoadd.py
+++ b/config/assembleCoadd.py
@@ -5,14 +5,8 @@ from lsst.obs.sdss.scaleSdssZeroPoint import ScaleSdssZeroPointTask
 config.select.retarget(SelectSdssImagesTask)
 config.scaleZeroPoint.retarget(ScaleSdssZeroPointTask)
 
-config.matchBackgrounds.usePolynomial = True
-config.matchBackgrounds.binSize = 128
-config.matchBackgrounds.order = 4
 config.subregionSize = (2500, 2500)
 config.sigmaClip = 5
-config.maxMatchResidualRatio = 1.7
-config.maxMatchResidualRMS = 1.0
-config.autoReference = False
 
 # Configs for deep coadd
 config.coaddName = 'deep'


### PR DESCRIPTION
Background matching has been removed in pipe_tasks (because it doesn't work
in the general case of pointed observations). Re-implementation in obs_sdss
awaits resources and motivation.