### PR TITLE
DM-12447: Remove TransformMap.transform, Camera.transform and Detector.transform

### DIFF
--- a/python/lsst/obs/sdss/makeCamera.py
+++ b/python/lsst/obs/sdss/makeCamera.py
@@ -235,7 +235,7 @@ def printCamera(title, camera):
         print("%s %dx%d centre (mm): %s" %
               (det.getName(),
                det.getBBox().getWidth(), det.getBBox().getHeight(),
-               det.getCenter(FOCAL_PLANE).getPoint()))
+               det.getCenter(FOCAL_PLANE)))
 
 
 def main():


### PR DESCRIPTION
instead of a CameraPoint