### PR TITLE
DM-13696: `get('fpC')` now returns exposure

### DIFF
--- a/python/lsst/obs/sdss/sdssNullIsr.py
+++ b/python/lsst/obs/sdss/sdssNullIsr.py
@@ -113,7 +113,8 @@ class SdssNullIsrTask(pipeBase.Task):
         - Calib is from tsField
         - Psf is from psField
         """
-        image = sensorRef.get("fpC").convertF()
+        originalExp = sensorRef.get("fpC").convertF()
+        image = originalExp.getMaskedImage().getImage()
         if self.config.removePedestal:
             image -= self.config.pedestalVal
         mask = sensorRef.get("fpM")


### PR DESCRIPTION
This requires a few simple fixes to maintain old behavior.
Specifically the `ImageF` must be extracted from the `Exposure` handed back
by `butler.get('fpC')`.