### PR TITLE
DM-6640: IsrTask is not a valid CmdLineTask

### DIFF
--- a/config/processCcd.py
+++ b/config/processCcd.py
@@ -1,3 +1,6 @@
+"""
+SDSS-specific overrides for ProcessCcdTask
+"""
 from lsst.obs.sdss.sdssNullIsr import SdssNullIsrTask
 
 # Read post-ISR data from fpC, fpM, asTrans, etc. files and remove overlap

--- a/config/runIsr.py
+++ b/config/runIsr.py
@@ -1,0 +1,6 @@
+"""
+SDSS-specific overrides for RunIsrTask
+"""
+from lsst.obs.sdss.sdssNullIsr import SdssNullIsrTask
+
+config.isr.retarget(SdssNullIsrTask)


### PR DESCRIPTION
This ticket adds a stand-alone runIsr.py script, as well as ensuring that runIsr.py and processCcd.py read the same ISR configuration files.
